### PR TITLE
Simplify what characters may surround tags or due dates

### DIFF
--- a/Specification.md
+++ b/Specification.md
@@ -94,14 +94,8 @@ It MUST start on the same line that the *item* starts on.
 It MAY be continued on the subsequent line(s),
 where each of them MUST be indented (preceded) by a sequence of four space characters (`    `).
 
-The *description* MAY contain the following tokens:
-- One *due date*
-- Any number of *tags*
-
-These tokens MUST be surrounded by blank characters or punctuation,
-except for such punctuation which the tokens themselves can consist of.
-
-Potential additional *due dates* MUST be disregarded.
+The *description* MAY contain any number of *tags*, and/or one *due date*.
+(Any additional *due dates* MUST be disregarded.)
 
 > #### Example
 >


### PR DESCRIPTION
Resolves https://github.com/jotaen/xit/issues/28.

In the end, I’m not sure it’s really worth to maintain a set of sophisticated (and complicated) rules for the surrounding characters of tags and due dates. It’s unambiguous where both tokens start, and that they end with the first “alien” character.

Should there ever be actual problems in practice, we can still adjust the rules.

I can also contribute one data point from [my file format for time-tracking (klog)](https://github.com/jotaen/klog/blob/main/Specification.md#tag). There, the spec also doesn’t define any rules for surrounding characters of tags, and there never were any issues due to them missing.