### PR TITLE
Rephrase rules for tags, and allow empty tag values

### DIFF
--- a/Specification.md
+++ b/Specification.md
@@ -151,24 +151,24 @@ The *due date* value MUST be representable by the gregorian calendar.
 
 *Tags* are annotations for categorising or filtering the data.
 
-A *tag* MUST start with the hash character (`#`),
-followed by one or more characters for the *name* of the *tag*.
-There MAY follow an equals sign (`=`)
-along with one or more characters for the *value* of the *tag*.
+A *tag* MUST consist of a *tag name*,
+which MUST be preceded by a single `#` character.
+The *tag name* MAY be followed by a `=` character and a *tag value*.
 
-*Tag names* MUST be treated as case-insensitive.
+The *tag name* MUST only contain letters, digits, or the characters `_` or `-`.
+It MUST be interpreted as if it was all lower-case.
 
-The *tag value* MAY be surrounded by a pair of matching quote characters (either `"`, or `'`).
+The *tag value* MAY be surrounded by a pair of matching quotes,
+which MUST either be `"` (RECOMMENDED) or `'`.
+- If the *tag value* is quoted, it MAY contain any character
+  except for the respective quote character itself, or a newline.
+  In case no matching closing quote appears on the same line,
+  the *tag value* MUST be treated as absent.
+- If the *tag value* is not quoted, it MUST only contain
+  letters, digits, or the characters `_` or `-`.
 
-*Tag names* and unquoted *tag values* MUST only contain
-letters, digits, the underscore character (`_`),
-and/or the hyphen character (`-`).
-
-Quoted *tag values* MAY contain any character,
-except for the respective quote itself
-or a newline.
-If there is no closing quote on the same line,
-the *tag value* MUST be treated as absent.
+An empty *tag value* (e.g. `#tag=` or `#tag=""`)
+MUST be treated the same as an absent *tag value* (e.g. `#tag`).
 
 > #### Example
 >


### PR DESCRIPTION
Resolves https://github.com/jotaen/xit/issues/27.

I’ve restructured the section, but the statements are the same as before, except that tag values (`#tag=value`) can be empty now. So all of `#tag=`, `#tag=''`, and `#tag=""` are allowed, and treated as equal to `#tag`.

From a strict language perspective, empty tag values don’t have any meaning of course. But I think, it’s more user-friendly to allow this syntactical invariant. That way, it’s always clear that the `=` has special meaning, as opposed to all other punctuation or symbols which might appear behind tags.

From a tooling perspective, there is no distinction between empty and absent tag value. So for `#tag`, `#tag=`, and `#tag=""`, the underlying tag value can just be empty string `""`.

The recommendation for the quotation style is mostly relevant for tools. Say e.g., there is a tool that allows users to enter a tag value via a form field in a UI. If the tool would detect that the value needs to be quoted, then it should default to using `"`. Except when the value contains a `"`, in which case the quotation must be `'`. (This implies that a tag value itself can never contain both `"` and `'`. That’s okay, though.)